### PR TITLE
Filter logs if blockheight has been set to a previous value

### DIFF
--- a/bsc/bridges/stellar/api/bridge/bridge_contract.go
+++ b/bsc/bridges/stellar/api/bridge/bridge_contract.go
@@ -500,7 +500,6 @@ func (bridge *BridgeContract) FilterWithdraw(wc chan<- WithdrawEvent, startHeigh
 	}
 
 	for withdrawEvent.Next() {
-		log.Info("e", "e", withdrawEvent.Event)
 		if withdrawEvent.Event == nil {
 			break
 		}
@@ -517,7 +516,6 @@ func (bridge *BridgeContract) FilterWithdraw(wc chan<- WithdrawEvent, startHeigh
 			raw:                withdrawEvent.Event.Raw.Data,
 		}
 	}
-	log.Info("returning now")
 	return nil
 }
 

--- a/bsc/bridges/stellar/api/bridge/bridge_contract.go
+++ b/bsc/bridges/stellar/api/bridge/bridge_contract.go
@@ -408,7 +408,7 @@ func (w WithdrawEvent) BlockHeight() uint64 {
 // SubscribeWithdraw subscribes to new Withdraw events on the given contract. This call blocks
 // and prints out info about any withdraw as it happened
 func (bridge *BridgeContract) SubscribeWithdraw(wc chan<- WithdrawEvent, startHeight uint64) error {
-	log.Debug("Subscribing to withdraw events", "start height", startHeight)
+	log.Info("Subscribing to withdraw events", "start height", startHeight)
 	sink := make(chan *contract.TokenWithdraw)
 	watchOpts := &bind.WatchOpts{Context: context.Background(), Start: nil}
 	sub, err := bridge.WatchWithdraw(watchOpts, sink, nil)
@@ -422,7 +422,6 @@ func (bridge *BridgeContract) SubscribeWithdraw(wc chan<- WithdrawEvent, startHe
 		case err = <-sub.Err():
 			return err
 		case withdraw := <-sink:
-
 			if withdraw.Raw.Removed {
 				// ignore removed events
 				continue
@@ -484,6 +483,42 @@ func (bridge *BridgeContract) WatchWithdraw(opts *bind.WatchOpts, sink chan<- *c
 			}
 		}
 	}), nil
+}
+
+// FilterWithdraw filters Withdraw events on the given contract. This call blocks
+// and prints out info about any withdraw as it happened
+func (bridge *BridgeContract) FilterWithdraw(wc chan<- WithdrawEvent, startHeight uint64, endHeight uint64) error {
+	log.Info("Filtering to withdraw events", "start height", startHeight)
+	filterOpts := bind.FilterOpts{
+		Start: startHeight,
+		End:   &endHeight,
+	}
+	withdrawEvent, err := bridge.tftContract.filter.FilterWithdraw(&filterOpts, nil)
+	if err != nil {
+		log.Error("filtering withdraw events failed", "err", err)
+		return err
+	}
+
+	for withdrawEvent.Next() {
+		log.Info("e", "e", withdrawEvent.Event)
+		if withdrawEvent.Event == nil {
+			break
+		}
+
+		log.Info("Withdraw event found", "event", withdrawEvent)
+		wc <- WithdrawEvent{
+			receiver:           withdrawEvent.Event.Receiver,
+			amount:             withdrawEvent.Event.Tokens,
+			txHash:             withdrawEvent.Event.Raw.TxHash,
+			blockHash:          withdrawEvent.Event.Raw.BlockHash,
+			blockHeight:        withdrawEvent.Event.Raw.BlockNumber,
+			blockchain_address: withdrawEvent.Event.BlockchainAddress,
+			network:            withdrawEvent.Event.Network,
+			raw:                withdrawEvent.Event.Raw.Data,
+		}
+	}
+	log.Info("returning now")
+	return nil
 }
 
 // TransferFunds transfers funds from one address to another


### PR DESCRIPTION
Sadly, passing the startheight to the WatchWithdraw function does not trigger a rescan for events on the contract from that height. So now we check if the blockheight is set to a previous value and if so we filter the contract for withdraw events from that startheight.