### PR TITLE
Revert mint retry

### DIFF
--- a/bsc/bridges/stellar/api/bridge/stellar.go
+++ b/bsc/bridges/stellar/api/bridge/stellar.go
@@ -175,7 +175,7 @@ func (w *stellarWallet) CreateAndSubmitPayment(ctx context.Context, target strin
 // mint handler
 type mint func(ERC20Address, *big.Int, string) error
 
-//MonitorBridgeAccountAndMint is a blocking function that keeps monitoring
+// MonitorBridgeAccountAndMint is a blocking function that keeps monitoring
 // the bridge account on the Stellar network for new transactions and calls the
 // mint function when a deposit is made
 func (w *stellarWallet) MonitorBridgeAccountAndMint(ctx context.Context, mintFn mint, persistency *ChainPersistency) error {
@@ -222,17 +222,12 @@ func (w *stellarWallet) MonitorBridgeAccountAndMint(ctx context.Context, mintFn 
 				depositedAmount := big.NewInt(int64(parsedAmount))
 
 				err = mintFn(ethAddress, depositedAmount, tx.Hash)
-				for err != nil {
+				if err != nil {
 					log.Error(fmt.Sprintf("Error occured while minting: %s", err.Error()))
-					select {
-					case <-ctx.Done():
-						return
-					case <-time.After(10 * time.Second):
-						err = mintFn(ethAddress, depositedAmount, tx.Hash)
-					}
+					return
 				}
-				log.Info("Mint succesfull, saving cursor")
 
+				log.Info("Mint succesfull, saving cursor")
 				// save cursor
 				cursor := tx.PagingToken()
 				err = persistency.saveStellarCursor(cursor)


### PR DESCRIPTION
Underlying functions called in the mint function already retry on no peer err..

https://github.com/threefoldfoundation/tft/blob/0c96b37cffc77ff5a4186317c2ae87f1aa2d6a7c/bsc/bridges/stellar/api/bridge/bridge.go#L109-L127

check mint txid: https://github.com/threefoldfoundation/tft/blob/0c96b37cffc77ff5a4186317c2ae87f1aa2d6a7c/bsc/bridges/stellar/api/bridge/bridge_contract.go#L641-L647

mint: https://github.com/threefoldfoundation/tft/blob/0c96b37cffc77ff5a4186317c2ae87f1aa2d6a7c/bsc/bridges/stellar/api/bridge/bridge_contract.go#L519-L525



AFAIK we can only retry a mint on no peers error, other failed mint should actually be stored somewhere so we can recover some details about failed mints (if there are any)