### PR TITLE
Add stellar transaction storage

### DIFF
--- a/bsc/bridges/stellar/api/bridge/bridge.go
+++ b/bsc/bridges/stellar/api/bridge/bridge.go
@@ -222,6 +222,11 @@ func (bridge *Bridge) Start(ctx context.Context) error {
 	// - Monitor the Bridge Stellar account and initiate Minting transactions accordingly
 	// - Monitor the Contract for Withdrawal events and initiate a Withdrawal transaction accordingly
 	if !bridge.config.Follower {
+		// Scan bridge account for outgoing transactions to avoid double withdraws or refunds
+		if err := bridge.wallet.ScanBridgeAccount(); err != nil {
+			panic(err)
+		}
+
 		// Monitor the bridge wallet for incoming transactions
 		// mint transactions on ERC20 if possible
 		go func() {

--- a/bsc/bridges/stellar/api/bridge/signer_server.go
+++ b/bsc/bridges/stellar/api/bridge/signer_server.go
@@ -3,9 +3,7 @@ package bridge
 import (
 	"context"
 	"encoding/base64"
-	"encoding/hex"
 	"fmt"
-	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -14,11 +12,8 @@ import (
 	"github.com/libp2p/go-libp2p-core/protocol"
 	gorpc "github.com/libp2p/go-libp2p-gorpc"
 	"github.com/multiformats/go-multiaddr"
-	"github.com/pkg/errors"
-	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
-	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
 )
@@ -43,12 +38,10 @@ type SignResponse struct {
 }
 
 type SignerService struct {
-	network               string
-	kp                    *keypair.Full
-	bridgeContract        *BridgeContract
-	knownTransactionMemos map[string]struct{}
-	bridgeMasterAddress   string
-	cursor                string
+	network                   string
+	kp                        *keypair.Full
+	bridgeContract            *BridgeContract
+	stellarTransactionStorage *StellarTransactionStorage
 }
 
 func NewSignerServer(host host.Host, network, secret, bridgeMasterAddress string, bridgeContract *BridgeContract) (*SignerService, error) {
@@ -118,7 +111,7 @@ func (s *SignerService) Sign(ctx context.Context, request SignRequest, response 
 			return fmt.Errorf("amount is not correct, received %d, need %d", paymentOperation.Amount, xdr.Int64(withdraw.Event.Tokens.Int64()))
 		}
 
-		err = s.checkExistingTransactionHash(txn)
+		err = s.stellarTransactionStorage.CheckForExistingTransactionHash(txn)
 		if err != nil {
 			log.Error("error while checking transaction hash", "err", err.Error())
 			return err
@@ -140,71 +133,8 @@ func (s *SignerService) Sign(ctx context.Context, request SignRequest, response 
 	return nil
 }
 
-func (s *SignerService) checkExistingTransactionHash(txn *txnbuild.Transaction) error {
-	txMemo, err := txn.Memo().ToXDR()
-	if err != nil {
-		return err
-	}
-
-	// only check transaction with hash memos
-	if txMemo.Type != xdr.MemoTypeMemoHash {
-		return nil
-	}
-
-	hashMemo := txn.Memo().(txnbuild.MemoHash)
-	txMemoString := hex.EncodeToString(hashMemo[:])
-
-	_, ok := s.knownTransactionMemos[txMemoString]
-	if ok {
-		return fmt.Errorf("transaction with memo %s already exists on bridge account %s", txMemoString, txn.SourceAccount().AccountID)
-	}
-
-	// trigger a rescan
-	// will not rescan from start since we saved the cursor
-	err = s.ScanBridgeAccount()
-	if err != nil {
-		return err
-	}
-
-	_, ok = s.knownTransactionMemos[txMemoString]
-	if ok {
-		return fmt.Errorf("transaction with memo %s already exists on bridge account %s", txMemoString, txn.SourceAccount().AccountID)
-	}
-	log.Info("transaction not found")
-
-	return nil
-}
-
 func (s *SignerService) ScanBridgeAccount() error {
-	if s.bridgeMasterAddress == "" {
-		return errors.New("no master bridge account set, aborting now")
-	}
-
-	transactionHandler := func(tx hProtocol.Transaction) {
-		if tx.MemoType != "hash" {
-			return
-		}
-
-		bytes, err := base64.StdEncoding.DecodeString(tx.Memo)
-		if err != nil {
-			return
-		}
-		memoAsHex := hex.EncodeToString(bytes)
-
-		_, ok := s.knownTransactionMemos[memoAsHex]
-		if !ok {
-			log.Info("found", "x", memoAsHex)
-			// add the transaction memo to the list of known transaction memos
-			s.knownTransactionMemos[memoAsHex] = struct{}{}
-		}
-	}
-
-	err := s.FetchTransactions(context.Background(), s.cursor, transactionHandler)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return s.stellarTransactionStorage.ScanBridgeAccount()
 }
 
 func newSignerServer(host host.Host, network, secret, bridgeMasterAddress string, bridgeContract *BridgeContract) (*gorpc.Server, *SignerService, error) {
@@ -215,12 +145,13 @@ func newSignerServer(host host.Host, network, secret, bridgeMasterAddress string
 	log.Debug("wallet address", "address", full.Address())
 	server := gorpc.NewServer(host, Protocol)
 
+	stellarTransactionStorage := NewStellarTransactionStorage(network, bridgeMasterAddress)
+
 	signer := SignerService{
-		network:               network,
-		kp:                    full,
-		bridgeContract:        bridgeContract,
-		bridgeMasterAddress:   bridgeMasterAddress,
-		knownTransactionMemos: make(map[string]struct{}),
+		network:                   network,
+		kp:                        full,
+		bridgeContract:            bridgeContract,
+		stellarTransactionStorage: stellarTransactionStorage,
 	}
 
 	err = server.Register(&signer)
@@ -237,59 +168,4 @@ func (s *SignerService) getNetworkPassPhrase() string {
 	default:
 		return network.TestNetworkPassphrase
 	}
-}
-
-// GetHorizonClient gets the horizon client based on the wallet's network
-func (s *SignerService) getHorizonClient() (*horizonclient.Client, error) {
-	switch s.network {
-	case "testnet":
-		return horizonclient.DefaultTestNetClient, nil
-	case "production":
-		return horizonclient.DefaultPublicNetClient, nil
-	default:
-		return nil, errors.New("network is not supported")
-	}
-}
-
-func (s *SignerService) FetchTransactions(ctx context.Context, cursor string, handler func(op hProtocol.Transaction)) error {
-	client, err := s.getHorizonClient()
-	if err != nil {
-		return err
-	}
-
-	opRequest := horizonclient.TransactionRequest{
-		ForAccount:    s.bridgeMasterAddress,
-		IncludeFailed: false,
-		Cursor:        s.cursor,
-		Limit:         stellarPageLimit,
-	}
-	log.Info("Start fetching stellar transactions", "horizon", client.HorizonURL, "account", opRequest.ForAccount, "cursor", opRequest.Cursor)
-
-	for {
-		if ctx.Err() != nil {
-			return nil
-		}
-
-		response, err := client.Transactions(opRequest)
-		if err != nil {
-			log.Info("Error getting transactions for stellar account", "error", err)
-			select {
-			case <-ctx.Done():
-				return nil
-			case <-time.After(5 * time.Second):
-				continue
-			}
-
-		}
-		for _, tx := range response.Embedded.Records {
-			handler(tx)
-			s.cursor = tx.PagingToken()
-			opRequest.Cursor = s.cursor
-		}
-		if len(response.Embedded.Records) == 0 {
-			return nil
-		}
-
-	}
-
 }

--- a/bsc/bridges/stellar/api/bridge/signer_server.go
+++ b/bsc/bridges/stellar/api/bridge/signer_server.go
@@ -113,7 +113,7 @@ func (s *SignerService) Sign(ctx context.Context, request SignRequest, response 
 		}
 
 		// check if a similar transaction was made before
-		err, exists := s.stellarTransactionStorage.TransactionHashExists(txn)
+		exists, err := s.stellarTransactionStorage.TransactionHashExists(txn)
 		if err != nil {
 			return errors.Wrap(err, "failed to check transaction storage for existing transaction hash")
 		}

--- a/bsc/bridges/stellar/api/bridge/stellar.go
+++ b/bsc/bridges/stellar/api/bridge/stellar.go
@@ -122,7 +122,7 @@ func (w *stellarWallet) CreateAndSubmitPayment(ctx context.Context, target strin
 	}
 
 	// check if a similar transaction was made before
-	err, exists := w.stellarTransactionStorage.TransactionHashExists(tx)
+	exists, err := w.stellarTransactionStorage.TransactionHashExists(tx)
 	if err != nil {
 		return errors.Wrap(err, "failed to check transaction storage for existing transaction hash")
 	}

--- a/bsc/bridges/stellar/api/bridge/stellar.go
+++ b/bsc/bridges/stellar/api/bridge/stellar.go
@@ -122,9 +122,12 @@ func (w *stellarWallet) CreateAndSubmitPayment(ctx context.Context, target strin
 	}
 
 	// check if a similar transaction was made before
-	// if there was, return nil because we don't execute the transaction and this is not an error
-	err = w.stellarTransactionStorage.CheckForExistingTransactionHash(tx)
+	err, exists := w.stellarTransactionStorage.TransactionHashExists(tx)
 	if err != nil {
+		return errors.Wrap(err, "failed to check transaction storage for existing transaction hash")
+	}
+	// if the transaction exists, return with nil error
+	if exists {
 		log.Info("Transaction with this hash already executed, skipping now..")
 		return nil
 	}

--- a/bsc/bridges/stellar/api/bridge/transaction_storage.go
+++ b/bsc/bridges/stellar/api/bridge/transaction_storage.go
@@ -29,16 +29,16 @@ func NewStellarTransactionStorage(network, addressToScan string) *StellarTransac
 	}
 }
 
-func (s *StellarTransactionStorage) TransactionHashExists(txn *txnbuild.Transaction) (error, bool) {
+func (s *StellarTransactionStorage) TransactionHashExists(txn *txnbuild.Transaction) (exists bool, err error) {
 	log.Info("checking tx hash")
 	txMemo, err := txn.Memo().ToXDR()
 	if err != nil {
-		return err, false
+		return
 	}
 
 	// only check transaction with hash memos
 	if txMemo.Type != xdr.MemoTypeMemoHash {
-		return nil, false
+		return
 	}
 
 	hashMemo := txn.Memo().(txnbuild.MemoHash)
@@ -46,23 +46,23 @@ func (s *StellarTransactionStorage) TransactionHashExists(txn *txnbuild.Transact
 
 	_, ok := s.knownTransactionMemos[txMemoString]
 	if ok {
-		return nil, true
+		return true, nil
 	}
 
 	// trigger a rescan
 	// will not rescan from start since we saved the cursor
 	err = s.ScanBridgeAccount()
 	if err != nil {
-		return err, false
+		return
 	}
 
 	_, ok = s.knownTransactionMemos[txMemoString]
 	if ok {
-		return nil, true
+		return true, nil
 	}
 	log.Info("transaction not found")
 
-	return nil, false
+	return
 }
 
 func (s *StellarTransactionStorage) ScanBridgeAccount() error {

--- a/bsc/bridges/stellar/api/bridge/transaction_storage.go
+++ b/bsc/bridges/stellar/api/bridge/transaction_storage.go
@@ -1,0 +1,154 @@
+package bridge
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stellar/go/clients/horizonclient"
+	hProtocol "github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/txnbuild"
+	"github.com/stellar/go/xdr"
+)
+
+type StellarTransactionStorage struct {
+	network               string
+	addressToScan         string
+	knownTransactionMemos map[string]struct{}
+	stellarCursor         string
+}
+
+func NewStellarTransactionStorage(network, addressToScan string) *StellarTransactionStorage {
+	return &StellarTransactionStorage{
+		network:               network,
+		addressToScan:         addressToScan,
+		knownTransactionMemos: make(map[string]struct{}),
+	}
+}
+
+func (s *StellarTransactionStorage) CheckForExistingTransactionHash(txn *txnbuild.Transaction) error {
+	log.Info("checking tx hash")
+	txMemo, err := txn.Memo().ToXDR()
+	if err != nil {
+		return err
+	}
+
+	// only check transaction with hash memos
+	if txMemo.Type != xdr.MemoTypeMemoHash {
+		return nil
+	}
+
+	hashMemo := txn.Memo().(txnbuild.MemoHash)
+	txMemoString := hex.EncodeToString(hashMemo[:])
+
+	_, ok := s.knownTransactionMemos[txMemoString]
+	if ok {
+		return fmt.Errorf("transaction with memo %s already exists on bridge account %s", txMemoString, txn.SourceAccount().AccountID)
+	}
+
+	// trigger a rescan
+	// will not rescan from start since we saved the cursor
+	err = s.ScanBridgeAccount()
+	if err != nil {
+		return err
+	}
+
+	_, ok = s.knownTransactionMemos[txMemoString]
+	if ok {
+		return fmt.Errorf("transaction with memo %s already exists on bridge account %s", txMemoString, txn.SourceAccount().AccountID)
+	}
+	log.Info("transaction not found")
+
+	return nil
+}
+
+func (s *StellarTransactionStorage) ScanBridgeAccount() error {
+	if s.addressToScan == "" {
+		return errors.New("no master bridge account set, aborting now")
+	}
+
+	transactionHandler := func(tx hProtocol.Transaction) {
+		if tx.MemoType != "hash" && tx.MemoType != "return" {
+			return
+		}
+
+		bytes, err := base64.StdEncoding.DecodeString(tx.Memo)
+		if err != nil {
+			return
+		}
+		memoAsHex := hex.EncodeToString(bytes)
+
+		_, ok := s.knownTransactionMemos[memoAsHex]
+		if !ok {
+			log.Info("storing memo hash in known transaction storage", "hash", memoAsHex)
+			// add the transaction memo to the list of known transaction memos
+			s.knownTransactionMemos[memoAsHex] = struct{}{}
+		}
+	}
+
+	err := s.FetchTransactions(context.Background(), s.stellarCursor, transactionHandler)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *StellarTransactionStorage) FetchTransactions(ctx context.Context, cursor string, handler func(op hProtocol.Transaction)) error {
+	client, err := s.getHorizonClient()
+	if err != nil {
+		return err
+	}
+
+	opRequest := horizonclient.TransactionRequest{
+		ForAccount:    s.addressToScan,
+		IncludeFailed: false,
+		Cursor:        s.stellarCursor,
+		Limit:         stellarPageLimit,
+	}
+	log.Info("Start fetching stellar transactions", "horizon", client.HorizonURL, "account", opRequest.ForAccount, "cursor", opRequest.Cursor)
+
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		response, err := client.Transactions(opRequest)
+		if err != nil {
+			log.Info("Error getting transactions for stellar account", "error", err)
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(5 * time.Second):
+				continue
+			}
+
+		}
+		for _, tx := range response.Embedded.Records {
+			handler(tx)
+			s.stellarCursor = tx.PagingToken()
+			opRequest.Cursor = s.stellarCursor
+		}
+		if len(response.Embedded.Records) == 0 {
+			return nil
+		}
+
+	}
+
+}
+
+// GetHorizonClient gets the horizon client based on the transaction storage's network
+func (s *StellarTransactionStorage) getHorizonClient() (*horizonclient.Client, error) {
+	switch s.network {
+	case "testnet":
+		return horizonclient.DefaultTestNetClient, nil
+	case "production":
+		return horizonclient.DefaultPublicNetClient, nil
+	default:
+		return nil, errors.New("network is not supported")
+	}
+}


### PR DESCRIPTION
Add a transaction storage that:

- Looks up all the transactions on a stellar address
- Saves all Stellar transaction that has a Hash in the Memo
- Can look up Memo hashes either in storage or on horizon