### PR TITLE
Fix withdraw retry

### DIFF
--- a/bsc/bridges/stellar/api/bridge/bridge.go
+++ b/bsc/bridges/stellar/api/bridge/bridge.go
@@ -308,6 +308,7 @@ func (bridge *Bridge) Start(ctx context.Context) error {
 						err := bridge.wallet.CreateAndSubmitPayment(ctx, we.blockchain_address, we.network, we.amount.Uint64(), we.receiver, we.blockHeight, hash)
 						if err != nil {
 							log.Error(fmt.Sprintf("failed to create payment for withdrawal to %s, %s", we.blockchain_address, err.Error()))
+							continue
 						}
 						// forget about our tx
 						delete(txMap, id)


### PR DESCRIPTION
instead of removed the txid from the transaction map, just continue so after the next blockdelay it gets tried again