### PR TITLE
fix: singing order & wait for tx mined status

### DIFF
--- a/bridge/stellar/api/bridge/bridge.go
+++ b/bridge/stellar/api/bridge/bridge.go
@@ -159,9 +159,6 @@ func (bridge *Bridge) mint(receiver ERC20Address, depositedAmount *big.Int, txID
 		return err
 	}
 
-	// Create signatures array with the required length
-	signs := make([]tokenv1.Signature, requiredSignatureCount.Int64())
-
 	res, err := bridge.wallet.client.SignMint(context.Background(), EthSignRequest{
 		Receiver: common.BytesToAddress(receiver[:]),
 		Amount:   amount.Int64(),
@@ -187,7 +184,7 @@ func (bridge *Bridge) mint(receiver ERC20Address, depositedAmount *big.Int, txID
 		return err
 	}
 
-	orderderedSignatures := make([]tokenv1.Signature, len(signers))
+	orderderedSignatures := make([]tokenv1.Signature, requiredSignatureCount.Int64())
 	for i := 0; i < len(signers); i++ {
 		for _, sign := range res {
 			if sign.Who == signers[i] {
@@ -198,9 +195,9 @@ func (bridge *Bridge) mint(receiver ERC20Address, depositedAmount *big.Int, txID
 
 	log.Debug("signers list", "l", signers)
 
-	log.Debug("total signatures count", "count", len(signs))
+	log.Debug("total signatures count", "count", len(orderderedSignatures))
 
-	return bridge.bridgeContract.Mint(receiver, amount, txID, signs)
+	return bridge.bridgeContract.Mint(receiver, amount, txID, orderderedSignatures)
 }
 
 // GetClient returns bridgecontract lightclient

--- a/bridge/stellar/api/bridge/bridge.go
+++ b/bridge/stellar/api/bridge/bridge.go
@@ -173,23 +173,27 @@ func (bridge *Bridge) mint(receiver ERC20Address, depositedAmount *big.Int, txID
 		return err
 	}
 
-	// First append the master signature
+	// First create the master signature
 	signature, err := bridge.bridgeContract.CreateTokenSignature(common.Address(receiver), amount.Int64(), txID)
 	if err != nil {
 		return err
 	}
-	signs[0] = signature
 
-	// Append signatures in order
-	// TODO: check what order
-	for i := 0; i < len(res); i++ {
-		// todo: verify signatures
-		signs[i+1] = res[i].Signature
-	}
+	// Append to the signatures array
+	res = append(res, EthSignResponse{Who: bridge.GetClient().address, Signature: signature})
 
 	signers, err := bridge.bridgeContract.GetSigners()
 	if err != nil {
 		return err
+	}
+
+	orderderedSignatures := make([]tokenv1.Signature, len(signers))
+	for i := 0; i < len(signers); i++ {
+		for _, sign := range res {
+			if sign.Who == signers[i] {
+				orderderedSignatures[i] = sign.Signature
+			}
+		}
 	}
 
 	log.Debug("signers list", "l", signers)


### PR DESCRIPTION
https://github.com/threefoldfoundation/tft/issues/207

Since replies from peers can come out of order we need to sort the signatures based on the order of signers in the token contract.

Also wait for TX to be mined and log additional information to the console.