### PR TITLE
fix: how we lookup transactions

### DIFF
--- a/bridge/stellar/api/bridge/signer_server.go
+++ b/bridge/stellar/api/bridge/signer_server.go
@@ -238,6 +238,7 @@ func (s *SignerService) validateWithdrawal(request StellarSignRequest, txn *txnb
 		}
 
 		if exits {
+			log.Info("Transaction with this hash already executed, skipping now..")
 			return fmt.Errorf("transaction already exists")
 		}
 	}
@@ -299,7 +300,7 @@ func (s *SignerService) validateRefundTransaction(request StellarSignRequest, tx
 		}
 		// if the transaction exists, return with error
 		if !exists {
-			// log.Info("Transaction with this hash already executed, skipping now..")
+			log.Info("Transaction with this hash already executed, skipping now..")
 			return fmt.Errorf("deposit transaction with hash does not exist")
 		}
 

--- a/bridge/stellar/api/bridge/stellar.go
+++ b/bridge/stellar/api/bridge/stellar.go
@@ -58,14 +58,14 @@ type signerWallet struct {
 	signatureCount int
 }
 
-func NewStellarWallet(ctx context.Context, config *StellarConfig, depositFee int64) (*stellarWallet, error) {
+func NewStellarWallet(ctx context.Context, config *StellarConfig, depositFee int64, stellarTransactionStorage *StellarTransactionStorage) (*stellarWallet, error) {
 	kp, err := keypair.ParseFull(config.StellarSeed)
 
 	if err != nil {
 		return nil, err
 	}
 
-	stellarTransactionStorage := NewStellarTransactionStorage(config.StellarNetwork, kp.Address())
+	// stellarTransactionStorage := NewStellarTransactionStorage(config.StellarNetwork, kp.Address())
 	w := &stellarWallet{
 		keypair:                   kp,
 		config:                    config,
@@ -283,9 +283,6 @@ func (w *stellarWallet) submitTransaction(ctx context.Context, txn txnbuild.Tran
 		return errors.Wrap(err, "error submitting transaction")
 	}
 	log.Info(fmt.Sprintf("transaction: %s submitted to the stellar network..", txResult.Hash))
-
-	// Store TX
-	w.stellarTransactionStorage.StoreTransaction(txResult)
 
 	return nil
 }

--- a/bridge/stellar/api/bridge/stellar.go
+++ b/bridge/stellar/api/bridge/stellar.go
@@ -65,7 +65,6 @@ func NewStellarWallet(ctx context.Context, config *StellarConfig, depositFee int
 		return nil, err
 	}
 
-	// stellarTransactionStorage := NewStellarTransactionStorage(config.StellarNetwork, kp.Address())
 	w := &stellarWallet{
 		keypair:                   kp,
 		config:                    config,
@@ -225,7 +224,7 @@ func (w *stellarWallet) submitTransaction(ctx context.Context, txn txnbuild.Tran
 	}
 
 	// check if the actual transaction to be submitted already happened on the stellar network
-	exists, err := w.stellarTransactionStorage.TransactionExists(tx)
+	exists, err := w.stellarTransactionStorage.TransactionWithMemoExists(tx)
 	if err != nil {
 		return errors.Wrap(err, "failed to check transaction storage for existing transaction hash")
 	}
@@ -283,6 +282,9 @@ func (w *stellarWallet) submitTransaction(ctx context.Context, txn txnbuild.Tran
 		return errors.Wrap(err, "error submitting transaction")
 	}
 	log.Info(fmt.Sprintf("transaction: %s submitted to the stellar network..", txResult.Hash))
+
+	// Store the transaction in the database
+	w.stellarTransactionStorage.StoreTransaction(txResult)
 
 	return nil
 }

--- a/bridge/stellar/api/bridge/stellar.go
+++ b/bridge/stellar/api/bridge/stellar.go
@@ -566,14 +566,7 @@ func (w *stellarWallet) GetHorizonClient() (*horizonclient.Client, error) {
 
 // GetNetworkPassPhrase gets the Stellar network passphrase based on the wallet's network
 func (w *stellarWallet) GetNetworkPassPhrase() string {
-	switch w.config.StellarNetwork {
-	case "testnet":
-		return network.TestNetworkPassphrase
-	case "production":
-		return network.PublicNetworkPassphrase
-	default:
-		return network.TestNetworkPassphrase
-	}
+	return GetNetworkPassPhrase(w.config.StellarNetwork)
 }
 
 func (w *stellarWallet) GetAssetCodeAndIssuer() []string {

--- a/bridge/stellar/api/bridge/stellar.go
+++ b/bridge/stellar/api/bridge/stellar.go
@@ -224,7 +224,7 @@ func (w *stellarWallet) submitTransaction(ctx context.Context, txn txnbuild.Tran
 		return errors.Wrap(err, "failed to build transaction")
 	}
 
-	// check if a similar transaction with a memo was made before
+	// check if the actual transaction to be submitted already happened on the stellar network
 	exists, err := w.stellarTransactionStorage.TransactionExists(tx)
 	if err != nil {
 		return errors.Wrap(err, "failed to check transaction storage for existing transaction hash")
@@ -599,6 +599,18 @@ func GetHorizonClient(network string) (*horizonclient.Client, error) {
 		return horizonclient.DefaultPublicNetClient, nil
 	default:
 		return nil, errors.New("network is not supported")
+	}
+}
+
+// GetNetworkPassPhrase gets the Stellar network passphrase based on a network input
+func GetNetworkPassPhrase(ntwrk string) string {
+	switch ntwrk {
+	case "testnet":
+		return network.TestNetworkPassphrase
+	case "production":
+		return network.PublicNetworkPassphrase
+	default:
+		return network.TestNetworkPassphrase
 	}
 }
 

--- a/bridge/stellar/api/bridge/transaction_storage.go
+++ b/bridge/stellar/api/bridge/transaction_storage.go
@@ -68,13 +68,6 @@ func (s *StellarTransactionStorage) TransactionExists(txn *txnbuild.Transaction)
 
 // TransactionWithMemoExists checks if a transaction with the given memo exists on the stellar network and also scans the bridge account for new transactions
 func (s *StellarTransactionStorage) TransactionWithMemoExists(txn *txnbuild.Transaction) (exists bool, err error) {
-	// trigger a rescan
-	// will not rescan from start since we saved the cursor
-	err = s.ScanBridgeAccount()
-	if err != nil {
-		return
-	}
-
 	memo, err := s.extractMemoFromTx(txn)
 	if err != nil || memo == "" {
 		return
@@ -93,6 +86,16 @@ func (s *StellarTransactionStorage) TransactionWithMemoExists(txn *txnbuild.Tran
 	}
 
 	return
+}
+
+// StoreTransaction stores a transaction in the transaction storage
+func (s *StellarTransactionStorage) StoreTransaction(txn hProtocol.Transaction) {
+	_, ok := s.knownTransactions[txn.Hash]
+	if !ok {
+		log.Info("storing memo hash in known transaction storage", "hash", txn.Hash)
+		// add the transaction memo to the list of known transaction memos
+		s.knownTransactions[txn.Hash] = txn
+	}
 }
 
 func (s *StellarTransactionStorage) ScanBridgeAccount() error {

--- a/bridge/stellar/api/bridge/transaction_storage.go
+++ b/bridge/stellar/api/bridge/transaction_storage.go
@@ -56,7 +56,7 @@ func (s *StellarTransactionStorage) transactionWthMemoExists(txn *txnbuild.Trans
 		return
 	}
 
-	log.Info("checking if transaction exists", "memo", memo)
+	log.Info("checking if transaction with memo exists in strorage..", "memo", memo)
 	// txhash here is equal to memo
 	for h := range s.knownTransactions {
 		if h == memo {
@@ -65,7 +65,6 @@ func (s *StellarTransactionStorage) transactionWthMemoExists(txn *txnbuild.Trans
 	}
 
 	if !exists {
-		log.Info("transaction not found")
 		return false, nil
 	}
 

--- a/bridge/stellar/main.go
+++ b/bridge/stellar/main.go
@@ -80,7 +80,13 @@ func main() {
 		log.Info("p2p node address", "address", full.String())
 	}
 
-	stellarWallet, err := bridge.NewStellarWallet(ctx, &stellarCfg, bridgeCfg.DepositFee)
+	txStorage := bridge.NewStellarTransactionStorage(stellarCfg.StellarNetwork, bridgeMasterAddress)
+	err = txStorage.ScanBridgeAccount()
+	if err != nil {
+		panic(err)
+	}
+
+	stellarWallet, err := bridge.NewStellarWallet(ctx, &stellarCfg, bridgeCfg.DepositFee, txStorage)
 	if err != nil {
 		panic(err)
 	}
@@ -101,14 +107,9 @@ func main() {
 		panic(err)
 	}
 
+	// Start the signer server
 	if bridgeCfg.Follower {
-		signer, err := bridge.NewSignerServer(host, bridgeMasterAddress, contract, stellarWallet)
-		if err != nil {
-			panic(err)
-		}
-
-		// Initially scan bridge account for stellar transactions
-		err = signer.StellarTransactionStorage.ScanBridgeAccount()
+		err := bridge.NewSignerServer(host, bridgeMasterAddress, contract, stellarWallet)
 		if err != nil {
 			panic(err)
 		}

--- a/solidity/scripts/withdraw.js
+++ b/solidity/scripts/withdraw.js
@@ -23,24 +23,20 @@ async function main () {
   const stellarAddress = args[6]
   const amount = parseInt(args[7])
 
-  // The address from the above deployment example
-  // let contractAddress = "0x2bD9aAa2953F988153c8629926D22A6a5F69b14E";
   const provider = new ethers.providers.WebSocketProvider(providerUrl, networkId)
-
-  console.log(await provider.getNetwork())
-
   const wallet = new ethers.Wallet(privateKey).connect(provider);
 
   // We get the contract to deploy
   const Token = await ethers.getContractFactory("contracts/tokenV1.sol:TFT", wallet)
   const token = Token.attach(tokenAddress)
 
-
   console.log("signer=", token.signer.address)
+
   const balance = await token.balanceOf(token.signer.address)
   console.log("balance=", balance.toString())
 
   await token.withdraw(amount, stellarAddress, "stellar")
+  console.log("tokens withdrawn")
 }
   
   main()

--- a/solidity/scripts/withdraw.js
+++ b/solidity/scripts/withdraw.js
@@ -1,0 +1,51 @@
+const { ethers } = require("hardhat");
+
+// scripts/deploy.js
+async function main () {
+  const args = process.argv
+
+  if (args.length < 5) {
+    console.log("Usage: withdraw.js <token_address> <private key> <provider url> <network id> <stellar address> <amount>")
+    console.log("Common networkIds:  mainnet: 1, goerli-testnet: 5, sepolia-testnet: 11155111")
+    process.exit(1)
+  }
+
+  const tokenAddress = args[2]
+  const privateKey = args[3]
+  console.log("privateKey=", privateKey)
+
+  const providerUrl = args[4]
+  console.log("providerUrl=", providerUrl)
+
+  const networkId = parseInt(args[5])
+  console.log("networkId=", networkId)
+
+  const stellarAddress = args[6]
+  const amount = parseInt(args[7])
+
+  // The address from the above deployment example
+  // let contractAddress = "0x2bD9aAa2953F988153c8629926D22A6a5F69b14E";
+  const provider = new ethers.providers.WebSocketProvider(providerUrl, networkId)
+
+  console.log(await provider.getNetwork())
+
+  const wallet = new ethers.Wallet(privateKey).connect(provider);
+
+  // We get the contract to deploy
+  const Token = await ethers.getContractFactory("contracts/tokenV1.sol:TFT", wallet)
+  const token = Token.attach(tokenAddress)
+
+
+  console.log("signer=", token.signer.address)
+  const balance = await token.balanceOf(token.signer.address)
+  console.log("balance=", balance.toString())
+
+  await token.withdraw(amount, stellarAddress, "stellar")
+}
+  
+  main()
+    .then(() => process.exit(0))
+    .catch(error => {
+      console.error(error);
+      process.exit(1);
+    });


### PR DESCRIPTION
Since https://github.com/threefoldfoundation/tft/commit/6d4aa007aca1601c83d7166d93e21e24770b7e55 we keep all transactions ever happened on the bridge account by key (hash) and value transaction we needed to fix how we looked up transactions in general. 

Transaction storage is now an object that is held by the StellarWallet struct for easier access and more unified style of accessing it.