### PR TITLE
Change solana destination address encoding

### DIFF
--- a/bridges/stellar-solana/api/bridge/bridge.go
+++ b/bridges/stellar-solana/api/bridge/bridge.go
@@ -139,6 +139,7 @@ func (bridge *Bridge) mint(ctx context.Context, memoAddress solana.Address, depo
 		return errors.Wrap(err, "could not convert memo master address to derived ATA")
 	}
 
+	log.Debug().Str("ATA", receiver.String()).Msg("Checking if computed receiver ATA is valid")
 	valid, err := bridge.solanaWallet.IsValidReceiver(ctx, receiver)
 	if err != nil {
 		return errors.Wrap(err, "Failed to check if receiver is proper")

--- a/bridges/stellar-solana/api/bridge/signer_server.go
+++ b/bridges/stellar-solana/api/bridge/signer_server.go
@@ -146,7 +146,15 @@ func (s *SignerService) SignMint(ctx context.Context, request SolanaRequest, res
 	if tx.MemoType != "hash" {
 		return errors.New("memo is not of type memo hash")
 	}
+
+	// Extract master address from stellar tx
 	addr, err := solana.AddressFromB64(tx.Memo)
+	if err != nil {
+		return err
+	}
+
+	// convert to ATA address, which is the one passed in the solana mint tx and the signing request
+	addr, err = s.solWallet.ATAFromMasterAddress(addr)
 	if err != nil {
 		return err
 	}

--- a/bridges/stellar-solana/solana/solana.go
+++ b/bridges/stellar-solana/solana/solana.go
@@ -347,7 +347,16 @@ func (sol *Solana) listTransactionSigs(ctx context.Context) ([]Signature, error)
 // ATAFromMasterAddress derives the expected ATA for the current mint assuming the given
 // adddress is the master account.
 func (sol *Solana) ATAFromMasterAddress(master Address) (Address, error) {
-	addr, _, err := solana.FindAssociatedTokenAddress(master, sol.tokenAddress)
+	// Rather than calling solana.FindAssociatedTokenAddress(master, sol.tokenAddress), we call the internal function that function call directly.
+	// The reason for this is that we use Token2022 programs, and the library uses the regular token program, which leads to different ATA derivations.
+	addr, _, err := solana.FindProgramAddress([][]byte{
+		master[:],
+		solana.Token2022ProgramID[:],
+		sol.tokenAddress[:],
+	},
+		solana.SPLAssociatedTokenAccountProgramID,
+	)
+
 	return addr, err
 }
 

--- a/bridges/stellar-solana/solana/solana.go
+++ b/bridges/stellar-solana/solana/solana.go
@@ -344,6 +344,13 @@ func (sol *Solana) listTransactionSigs(ctx context.Context) ([]Signature, error)
 	return signatures, nil
 }
 
+// ATAFromMasterAddress derives the expected ATA for the current mint assuming the given
+// adddress is the master account.
+func (sol *Solana) ATAFromMasterAddress(master Address) (Address, error) {
+	addr, _, err := solana.FindAssociatedTokenAddress(master, sol.tokenAddress)
+	return addr, err
+}
+
 // AddressFromHex decodes a hex encoded Solana address
 func AddressFromHex(encoded string) (Address, error) {
 	b, err := hex.DecodeString(encoded)


### PR DESCRIPTION
Provide the wallet master address instead of the ATA directly. The expected ATA is derived from the master address provided during processing.

To remain backwars compatible, reshuffle the check to see if we've already minted to the beginning of the mint function (and mint sign function in cosigners), and add a function to check if this tx has already been refunded after that. Especially the latter is important since previously refunded txes would now be valid, causing the check to see if the refund already happened to not happen as that lives specifically in the refund handler, which would not be invoked in this case.